### PR TITLE
docs: Add ADRs for frontend technology choices

### DIFF
--- a/docs/adrs/002-use-firebase-hosting.md
+++ b/docs/adrs/002-use-firebase-hosting.md
@@ -1,0 +1,28 @@
+# 2. Use Firebase App Hosting for Frontend Deployment
+
+## Status
+
+Accepted
+
+## Context
+
+We need a reliable, scalable, and easy-to-manage solution for hosting and deploying the frontend of the Cloud Coffee Corner application. The frontend consists of static assets (HTML, CSS, JavaScript) that need to be delivered globally with low latency. Key requirements include a streamlined developer experience, integration with a CI/CD pipeline, and built-in features like SSL and CDN.
+
+## Decision
+
+We will use **Firebase App Hosting** to serve the frontend of the application.
+
+## Consequences
+
+### Positive
+
+*   **Simplicity and Speed:** Firebase Hosting is designed for simplicity. Deploying the frontend is typically a single command (`firebase deploy`), which simplifies the CI/CD pipeline.
+*   **Global CDN:** All deployed assets are automatically cached on Firebase's global CDN, ensuring fast delivery to users anywhere in the world.
+*   **Zero-Config SSL:** SSL certificates are provisioned and renewed automatically, ensuring the application is secure without manual configuration.
+*   **Tight Integration:** Firebase is tightly integrated with other Google Cloud services, which aligns with our overall technology stack.
+*   **Versioning and Rollbacks:** Firebase Hosting keeps a history of deployments, allowing for easy one-click rollbacks to a previous version if a bug is discovered.
+
+### Negative
+
+*   **Platform Lock-in:** While it integrates well with Google Cloud, it is a proprietary service. Migrating to another hosting provider in the future would require changes to the deployment process.
+*   **Limited Server-Side Logic:** Firebase Hosting is primarily for static assets. While it can be integrated with Cloud Functions for server-side logic, it is not a traditional server environment. This is acceptable for our architecture, as all dynamic logic is handled by our backend microservices.

--- a/docs/adrs/003-use-angular-framework.md
+++ b/docs/adrs/003-use-angular-framework.md
@@ -1,0 +1,29 @@
+# 3. Use Angular for Frontend Development
+
+## Status
+
+Accepted
+
+## Context
+
+We need to select a modern, robust, and well-supported framework for developing the frontend of the Cloud Coffee Corner application. The framework must support a component-based architecture, provide strong tooling for development and testing, and be suitable for building a scalable single-page application (SPA). The development team has experience with multiple modern frameworks.
+
+## Decision
+
+We will use **Angular** as the primary framework for frontend development.
+
+## Consequences
+
+### Positive
+
+*   **Comprehensive and Opinionated:** Angular is a "batteries-included" framework. It provides built-in solutions for routing, state management, and data fetching (via its HTTP client). This reduces the need to make decisions about third-party libraries and ensures a consistent development pattern across the team.
+*   **Strong Tooling:** The Angular CLI is a powerful tool that streamlines project creation, component generation, and the build process.
+*   **TypeScript Support:** Angular is built with TypeScript, which provides static typing. This helps catch errors early, improves code quality, and makes the application easier to maintain and refactor.
+*   **Component-Based Architecture:** Angular's component model aligns perfectly with our goal of building a modular and reusable UI.
+*   **Long-Term Support:** As a Google-backed framework, Angular has a clear roadmap and long-term support, which is beneficial for the project's longevity.
+
+### Negative
+
+*   **Learning Curve:** Angular can have a steeper learning curve compared to other frameworks like React or Vue, especially for developers new to its specific patterns (e.g., modules, dependency injection).
+*   **Verbosity:** The framework can sometimes be more verbose than alternatives, requiring more boilerplate code for components and services.
+*   **Bundle Size:** While modern Angular has made significant improvements with its Ivy compiler, historically, its bundle sizes have been larger than competitors. This is a factor to monitor for performance.


### PR DESCRIPTION
This pull request adds two architectural decision records (ADRs) to document key technology choices for the frontend:

*   **ADR-002:** Documents the decision to use Firebase App Hosting for serving the frontend.
*   **ADR-003:** Documents the decision to use the Angular framework for frontend development.

These ADRs provide a clear record of the rationale behind these important architectural decisions.